### PR TITLE
configure.ac: build "quietly" if possible

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -23,6 +23,7 @@ AC_PREREQ(2.61)
 AC_INIT([usbhid-dump], [1.4])
 AC_CONFIG_AUX_DIR([auxdir])
 AM_INIT_AUTOMAKE([1.9 -Wall foreign])
+m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES([yes])])
 AM_MAINTAINER_MODE
 AC_CONFIG_HEADER([config.h])
 AC_CONFIG_MACRO_DIR([m4])


### PR DESCRIPTION
If autoconfig supports "quiet" builds, do it, to better be able to see
anything that might be warnings or errors in the build.
