### PR TITLE
usbhid-dump.c: remove deprecated libusb_set_debug() call

### DIFF
--- a/src/usbhid-dump.c
+++ b/src/usbhid-dump.c
@@ -526,8 +526,8 @@ run(bool            dump_descriptor,
     /* Create libusb context */
     LIBUSB_GUARD(libusb_init(&ctx), "create libusb context");
 
-    /* Set libusb debug level */
-    libusb_set_debug(ctx, 3);
+    /* Set libusb debug level to informational only */
+    libusb_set_option(ctx, LIBUSB_OPTION_LOG_LEVEL, LIBUSB_LOG_LEVEL_INFO);
 
     /* Open device list */
     LIBUSB_GUARD(uhd_dev_list_open(ctx, bus_num, dev_addr,


### PR DESCRIPTION
Replace libusb_set_debug() with the "correct" libusb_set_option() call.
This removes a warning message from the build on newer versions of
libusb.

Signed-off-by: Greg Kroah-Hartman <gregkh@linuxfoundation.org>