### PR TITLE
Build Github Action (Latest Ubuntu)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,24 @@
+name: Build
+
+on: push
+
+jobs:
+  ubuntu-build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Dependencies
+      run: |
+        sudo apt install libtool libusb-1.0-0-dev
+
+    - run: ./bootstrap
+
+    - run: ./configure
+
+    - run: make
+
+    - run: sudo make install
+
+

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ Installation
 
 Run `./configure && make` to build and `make install` to install. If building from a Git tree, run `./bootstrap` first. Usbhid-dump can also be run directly from the source directory as `src/usbhid-dump`, without installation.
 
+Example: [![Build](https://github.com/DIGImend/usbhid-dump/actions/workflows/build.yml/badge.svg)](https://github.com/DIGImend/usbhid-dump/actions/workflows/build.yml)
+
 Usage
 -----
 


### PR DESCRIPTION
This commit adds a workflow building `usbhid-dump` in an Ubuntu environment. 
It also adds a badge in the `Installation` section of the README.

I wrote it as when libtool and libusb-dev are not installed, the error message are not very clear (mixed with autoconf deprecated warnings) thus I lost some time.

Hoping this could help others to save their one.

Run result: https://github.com/jclaveau/usbhid-dump/actions/runs/5105232219/jobs/9176685806
